### PR TITLE
🩹fix(auth): 修复 OAuth2 refresh_token 时反序列化 attributes 字段出错的问题

### DIFF
--- a/youlai-auth/src/main/java/com/youlai/auth/config/AuthorizationServerConfig.java
+++ b/youlai-auth/src/main/java/com/youlai/auth/config/AuthorizationServerConfig.java
@@ -11,6 +11,7 @@ import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
+import com.youlai.auth.model.MemberDetails;
 import com.youlai.auth.model.SysUserDetails;
 import com.youlai.auth.oauth2.extension.captcha.CaptchaAuthenticationConverter;
 import com.youlai.auth.oauth2.extension.captcha.CaptchaAuthenticationProvider;
@@ -271,6 +272,7 @@ public class AuthorizationServerConfig {
         // 添加自定义Mixin，用于序列化/反序列化特定的类。
         // Mixin类需要自行实现，以便Jackson可以处理这些类的序列化。
         objectMapper.addMixIn(SysUserDetails.class, SysUserMixin.class);
+        objectMapper.addMixIn(MemberDetails.class, MemberMixin.class);
         objectMapper.addMixIn(Long.class, Object.class);
 
         // 将配置好的ObjectMapper设置到行映射器中。

--- a/youlai-auth/src/main/java/com/youlai/auth/model/MemberDetails.java
+++ b/youlai-auth/src/main/java/com/youlai/auth/model/MemberDetails.java
@@ -2,6 +2,7 @@ package com.youlai.auth.model;
 
 import com.youlai.common.constant.GlobalConstants;
 import com.youlai.mall.ums.dto.MemberAuthDTO;
+import java.util.HashSet;
 import lombok.Data;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -53,7 +54,7 @@ public class MemberDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.EMPTY_SET;
+    return new HashSet<>();
     }
 
     @Override

--- a/youlai-auth/src/main/java/com/youlai/auth/oauth2/jackson/MemberMixin.java
+++ b/youlai-auth/src/main/java/com/youlai/auth/oauth2/jackson/MemberMixin.java
@@ -1,0 +1,23 @@
+package com.youlai.auth.oauth2.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * SysUserDetails 反序列化注册
+ *
+ * <p>刷新模式根据 refresh_token 从 oauth2_authorization 表中获取字段 attributes 内容反序列化成
+ *
+ * @author haoxr
+ * @since 2023/7/4
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+@JsonDeserialize(using = SysUserDeserializer.class)
+@JsonAutoDetect(
+    fieldVisibility = JsonAutoDetect.Visibility.ANY,
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MemberMixin {}


### PR DESCRIPTION
该问题出现在使用 MemberDetails 对象作为认证用户详情时，由于未将相关类添加至反序列化白名单，导致在使用 refresh_token 刷新令牌时抛出异常。

修复内容包括：
- 将 MemberDetails 类添加至反序列化白名单，避免抛出 “MemberDetails is not in the allowlist” 异常。
- 将 java.util.Collections$EmptySet 添加至白名单，解决 “The class with java.util.Collections$EmptySet is not in the allowlist” 异常。

该修复确保 OAuth2 授权流程中 refresh_token 能够正常工作，避免反序列化失败导致认证中断。